### PR TITLE
Add compatibility with Apple Silicon M1 (`arm64`)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyQt5==5.15.1
-tuyapy==0.1.3
-requests==2.24.0
+PyQt6==6.4.0
+tuyapy==0.1.4
+requests==2.28.1

--- a/tuya-tray.py
+++ b/tuya-tray.py
@@ -1,7 +1,7 @@
 import sys
-from PyQt5.QtWidgets import QApplication,QSystemTrayIcon,QMenu,QColorDialog
-from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import QCoreApplication
+from PyQt6.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QColorDialog
+from PyQt6.QtGui import QIcon
+from PyQt6.QtCore import QCoreApplication
 from tuyapy import TuyaApi
 import os
 import time
@@ -91,4 +91,4 @@ if __name__ == "__main__":
         app = QApplication(sys.argv)
     app.setQuitOnLastWindowClosed(False)
     tray = SystemTrayIcon()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())


### PR DESCRIPTION
Qt5 doesn't support the M1 chip, so bumped the requirements and got the application running with `PyQt6`. There's a few things that Qt6 does differently, but this was the minimum required changeset to get this working, so PR'd this for now if you're interested.